### PR TITLE
style(basename): Fix in all Tkinter section lectures

### DIFF
--- a/course_contents/19_gui_development_tkinter/lectures/11_opening_files/app.py
+++ b/course_contents/19_gui_development_tkinter/lectures/11_opening_files/app.py
@@ -15,7 +15,7 @@ def open_file():
     file_path = filedialog.askopenfilename()
 
     try:
-        filename = file_path.split("/")[-1]
+        filename = os.path.basename(file_path)
 
         with open(file_path, "r") as file:
             content = file.read()
@@ -31,7 +31,7 @@ def save_file():
     file_path = filedialog.asksaveasfilename()
 
     try:
-        filename = file_path.split("/")[-1]
+        filename = os.path.basename(file_path)
         text_widget = root.nametowidget(notebook.select())
         content = text_widget.get("1.0", "end-1c")
 

--- a/course_contents/19_gui_development_tkinter/lectures/12_binding_shortcuts/app.py
+++ b/course_contents/19_gui_development_tkinter/lectures/12_binding_shortcuts/app.py
@@ -15,7 +15,7 @@ def open_file():
     file_path = filedialog.askopenfilename()
 
     try:
-        filename = file_path.split("/")[-1]
+        filename = os.path.basename(file_path)
 
         with open(file_path, "r") as file:
             content = file.read()
@@ -31,7 +31,7 @@ def save_file():
     file_path = filedialog.asksaveasfilename()
 
     try:
-        filename = file_path.split("/")[-1]
+        filename = os.path.basename(file_path)
         text_widget = root.nametowidget(notebook.select())
         content = text_widget.get("1.0", "end-1c")
 

--- a/course_contents/19_gui_development_tkinter/lectures/13_checking_unsaved_changes/app.py
+++ b/course_contents/19_gui_development_tkinter/lectures/13_checking_unsaved_changes/app.py
@@ -37,7 +37,7 @@ def open_file():
     file_path = filedialog.askopenfilename()
 
     try:
-        filename = file_path.split("/")[-1]
+        filename = os.path.basename(file_path)
 
         with open(file_path, "r") as file:
             content = file.read()
@@ -53,7 +53,7 @@ def save_file():
     file_path = filedialog.asksaveasfilename()
 
     try:
-        filename = file_path.split("/")[-1]
+        filename = os.path.basename(file_path)
         text_widget = get_text_widget()
         content = text_widget.get("1.0", "end-1c")
 

--- a/course_contents/19_gui_development_tkinter/lectures/14_confirm_exit_with_unsaved_changes/app.py
+++ b/course_contents/19_gui_development_tkinter/lectures/14_confirm_exit_with_unsaved_changes/app.py
@@ -61,7 +61,7 @@ def open_file():
     file_path = filedialog.askopenfilename()
 
     try:
-        filename = file_path.split("/")[-1]
+        filename = os.path.basename(file_path)
 
         with open(file_path, "r") as file:
             content = file.read()
@@ -77,7 +77,7 @@ def save_file():
     file_path = filedialog.asksaveasfilename()
 
     try:
-        filename = file_path.split("/")[-1]
+        filename = os.path.basename(file_path)
         text_widget = get_text_widget()
         content = text_widget.get("1.0", "end-1c")
 

--- a/course_contents/19_gui_development_tkinter/lectures/15_closing_individual_tabs/app.py
+++ b/course_contents/19_gui_development_tkinter/lectures/15_closing_individual_tabs/app.py
@@ -78,7 +78,7 @@ def open_file():
     file_path = filedialog.askopenfilename()
 
     try:
-        filename = file_path.split("/")[-1]
+        filename = os.path.basename(file_path)
 
         with open(file_path, "r") as file:
             content = file.read()
@@ -94,7 +94,7 @@ def save_file():
     file_path = filedialog.asksaveasfilename()
 
     try:
-        filename = file_path.split("/")[-1]
+        filename = os.path.basename(file_path)
         text_widget = get_text_widget()
         content = text_widget.get("1.0", "end-1c")
 

--- a/course_contents/19_gui_development_tkinter/lectures/16_adding_another_menu/app.py
+++ b/course_contents/19_gui_development_tkinter/lectures/16_adding_another_menu/app.py
@@ -79,7 +79,7 @@ def open_file():
     file_path = filedialog.askopenfilename()
 
     try:
-        filename = file_path.split("/")[-1]
+        filename = os.path.basename(file_path)
 
         with open(file_path, "r") as file:
             content = file.read()
@@ -95,7 +95,7 @@ def save_file():
     file_path = filedialog.asksaveasfilename()
 
     try:
-        filename = file_path.split("/")[-1]
+        filename = os.path.basename(file_path)
         text_widget = get_text_widget()
         content = text_widget.get("1.0", "end-1c")
 

--- a/course_contents/19_gui_development_tkinter/lectures/17_adding_permanent_scrollbar/app.py
+++ b/course_contents/19_gui_development_tkinter/lectures/17_adding_permanent_scrollbar/app.py
@@ -30,7 +30,7 @@ def get_current_tab():
 def close_current_tab():
     if current_tab_unsaved() and not confirm_close():
         return
-    
+
     current_tab = get_current_tab()
 
     if len(notebook.tabs()) == 1:
@@ -93,7 +93,7 @@ def open_file():
     file_path = filedialog.askopenfilename()
 
     try:
-        filename = file_path.split("/")[-1]
+        filename = os.path.basename(file_path)
 
         with open(file_path, "r") as file:
             content = file.read()
@@ -109,7 +109,7 @@ def save_file():
     file_path = filedialog.asksaveasfilename()
 
     try:
-        filename = file_path.split("/")[-1]
+        filename = os.path.basename(file_path)
         text_widget = get_text_widget()
         content = text_widget.get("1.0", "end-1c")
 


### PR DESCRIPTION
After this Udemy Q&A, noticed that the video and this repo had slightly differing versions of the code for finding the basename of a file.

https://www.udemy.com/course/the-complete-python-course/learn/#questions/17664900/

This PR fixes the issue in all lectures present, except lecture 10 which was fixed by #42 